### PR TITLE
Workaround for static.unrest.io no longer serving unrest-built.js

### DIFF
--- a/media/templates/photo/dropphoto.html
+++ b/media/templates/photo/dropphoto.html
@@ -17,7 +17,7 @@
 {% endcompress %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/riot/2.6.7/riot+compiler.min.js"></script>
 <script src="{{ STATIC_URL }}tags/photo-list.tag" type="riot/tag"></script>
-<script src="https://static.unrest.io/.dist/unrest-built.js"></script>
+<script src="{{ STATIC_URL }}/unrest/.dist/unrest-built.js"></script>
 <script>window._PHOTOS = { photos: {{ photos|safe }}, content_type: "{{ content_type }}", object_id: {{ obj.id }} }</script>
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" />
 {% endspaceless %}


### PR DESCRIPTION
This template relies on files no longer being served at the specified location. 